### PR TITLE
Add Support for PackageReference

### DIFF
--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -66,6 +66,28 @@ describe('csproj', () => {
       });
     });
 
+    it('should parse packages from csproj when provided', () => {
+      const contents = fs.readFileSync('./test/data/TestConsoleApplication/TestNUnit4/TestNUnit4.csproj', { encoding: 'utf-8' });
+      const promise = csproj.parseProject(contents);
+
+      return promise.then(result => {
+        assert.exists(result.packages);
+        assert.isArray(result.packages);
+        assert.isAbove(result.packages.length, 0);
+      });
+    });
+
+    it('should return empty packages array from csproj when missing', () => {
+      const contents = fs.readFileSync('./test/data/TestConsoleApplication/TestNUnit2/TestNUnit2.csproj', { encoding: 'utf-8' });
+      const promise = csproj.parseProject(contents);
+
+      return promise.then(result => {
+        assert.exists(result.packages);
+        assert.isArray(result.packages);
+        assert.strictEqual(result.packages.length, 0);
+      });
+    });
+
     it('should read as file contents when buffer provided', () => {
       const contents = fs.readFileSync('./test/data/TestConsoleApplication/TestNUnit2/TestNUnit2.csproj');
       const promise = csproj.parseProject(contents);

--- a/test/data/TestConsoleApplication/TestConsoleApplication.sln
+++ b/test/data/TestConsoleApplication/TestConsoleApplication.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConsoleApplication", "T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNUnit3", "TestNUnit3\TestNUnit3.csproj", "{1580E0CD-6DAA-4328-92F6-2E0B0F0AB7AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNUnit4", "TestNUnit4\TestNUnit4.csproj", "{24E88346-B703-4D69-856A-E50D235A6D44}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNUnit2", "TestNUnit2\TestNUnit2.csproj", "{4F789118-2C18-4F6F-9F0A-81741E2262F9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConsoleLib", "TestConsoleLib\TestConsoleLib.csproj", "{F0387ABC-0DF5-4090-A146-B0780AC71400}"

--- a/test/data/TestConsoleApplication/TestNUnit4/Properties/AssemblyInfo.cs
+++ b/test/data/TestConsoleApplication/TestNUnit4/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("TestNUnit4")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestNUnit4")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("8121ee41-fd06-45a5-87c3-4bfa1438f1d6")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/data/TestConsoleApplication/TestNUnit4/TestNUnit4.csproj
+++ b/test/data/TestConsoleApplication/TestNUnit4/TestNUnit4.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8121EE41-FD06-45A5-87C3-4BFA1438F1D6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestNUnit4</RootNamespace>
+    <AssemblyName>TestNUnit4</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" targetFramework="net452" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" targetFramework="net452" />
+    <PackageReference Include="NUnit" Version="3.7.1" targetFramework="net452" />
+    <PackageReference Include="NUnit.Console" Version="3.7.0" targetFramework="net452" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" targetFramework="net452" />
+    <PackageReference Include="NUnit.Extension.NUnitProjectLoader" Version="3.5.0" targetFramework="net452" />
+    <PackageReference Include="NUnit.Extension.NUnitV2Driver" Version="3.6.0" targetFramework="net452" />
+    <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.5.0" targetFramework="net452" />
+    <PackageReference Include="NUnit.Extension.TeamCityEventListener" Version="1.0.2" targetFramework="net452" />
+    <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.5.0" targetFramework="net452" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TestConsoleLib\TestConsoleLib.csproj">
+      <Project>{f0387abc-0df5-4090-a146-b0780ac71400}</Project>
+      <Name>TestConsoleLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/test/data/TestConsoleApplication/TestNUnit4/UnitTest1.cs
+++ b/test/data/TestConsoleApplication/TestNUnit4/UnitTest1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestNUnit4
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/test/data/TestConsoleApplication/TestNUnit4/packages.config
+++ b/test/data/TestConsoleApplication/TestNUnit4/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Console.Test" version="3.7.0" targetFramework="net452" />
+</packages>

--- a/test/sln.test.js
+++ b/test/sln.test.js
@@ -81,7 +81,7 @@ describe('sln', () => {
 
             it('should have expected length', () => {
               const projects = solutionData.projects;
-              assert.equal(projects.length, 6);
+              assert.equal(projects.length, 7);
 
               for(let i=0; i < projects.length; i++) {
                 assert.isObject(projects[i]);
@@ -162,7 +162,6 @@ describe('sln', () => {
 
         assertIsDeepParsedProject(proj);
       });
-
       it('should deep parse from buffer when requested', () => {
         const parseOptions = { deepParse: true, dirRoot };
         const data = sln.parseSolutionSync(buffer, parseOptions);
@@ -188,6 +187,17 @@ describe('sln', () => {
         const parseOptions = { deepParse: true };
         assert.throws(() => sln.parseSolutionSync(text, parseOptions));
       });
+
+      it('should merge package data on deep parse', () => {
+        const parseOptions = { deepParse: true };
+        const data = sln.parseSolutionSync(filePath, parseOptions);
+        const proj = data.projects.find(proj => proj.name === 'TestNUnit4');
+
+        assertIsDeepParsedProject(proj);
+        assert.equal(proj.packages.length, 11);
+        assert.equal(proj.packages.filter(p => p.name === "NUnit.Console.Test").length > 0, true);
+      });
+
     });
 
     describe('async', () => {


### PR DESCRIPTION
#### Description
csproj files now allow defining all packages with the `PackageReference` property.  This PR adds support for it.  The updated logic will merge package references if found in both `csproj` and `packages.config`.  Added corresponding tests.  Semi-confident I updated the test cases properly!