### PR TITLE
Parse optional props as null instead of undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Change Log
 
-## [2.0.1](https://github.com/stevenaw/vs-parse/compare/v2.0.0...v2.0.1) (TBD)
+## [3.0.0](https://github.com/stevenaw/vs-parse/compare/v2.0.0...v3.0.0) (TBD)
+- BREAKING: The following optional properties of a parsed project now default to `null` instead of `undefined`:
+  - version
+  - culture
+  - processorArchitecture
+  - publicKeyToken
+  - hintPath
+- BREAKING: The following optional properties of a parsed solution now default to `null` instead of `undefined`:
+  - fileFormatVersion
+  - visualStudioVersion
+  - minimumVisualStudioVersion
 - Add CI testing for Node 14
 
 ## [2.0.0](https://github.com/stevenaw/vs-parse/compare/v1.2.2...v2.0.0) (2019-12-31)
-- Drop Node 6 support
+- BREAKING: Drop Node 6 support
 - Update test utilities
 - Remove Travis CI
 

--- a/src/csproj.js
+++ b/src/csproj.js
@@ -18,11 +18,11 @@ const parseAssemblyReference = (node) => {
 
   const result = {
     assemblyName: parts[0],
-    version: undefined,
-    culture: undefined,
-    processorArchitecture: undefined,
-    publicKeyToken: undefined,
-    hintPath: undefined,
+    version: null,
+    culture: null,
+    processorArchitecture: null,
+    publicKeyToken: null,
+    hintPath: null,
   };
 
   for(let i = 1; i < parts.length; i++) {

--- a/src/internal.js
+++ b/src/internal.js
@@ -19,7 +19,7 @@ const getFileDirectory = (filePath, options) => {
   const dir = (isVsFileContents(filePath) || isBuffer(filePath))
                   ? options.dirRoot
                   : path.dirname(filePath);
-                  
+
   if (!dir) {
     throw new Error('Could not determine root directory. Please specify \'dirRoot\' if doing a deep parse');
   }

--- a/src/sln.js
+++ b/src/sln.js
@@ -109,9 +109,9 @@ const parseSolutionInternal = (contents) => {
   const lines = contents.replace(/(\r\n|\r)/g, '\n').split('\n');
 
   const returnValue = {
-    fileFormatVersion: undefined,
-    visualStudioVersion: undefined,
-    minimumVisualStudioVersion: undefined,
+    fileFormatVersion: null,
+    visualStudioVersion: null,
+    minimumVisualStudioVersion: null,
     projects: []
   };
 
@@ -130,7 +130,7 @@ const parseSolutionInternal = (contents) => {
     if(visualStudioVersion) {
       returnValue.visualStudioVersion = visualStudioVersion;
     }
-    
+
     const minimumVisualStudioVersion = parseMinimumVisualStudioVersion(lines[i]);
     if(minimumVisualStudioVersion) {
       returnValue.minimumVisualStudioVersion = minimumVisualStudioVersion;

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -174,7 +174,10 @@ describe('csproj', () => {
 
             it('should parse code files correctly', () => {
               for(let i=0; i < projectData.codeFiles.length; i++) {
-                assert.strictEqual(projectData.codeFiles[i].fileName, expectedData.codeFiles[i].fileName);
+                const actualValue = projectData.codeFiles[i].fileName;
+                const expectedValue = helpers.normalizePath(expectedData.codeFiles[i].fileName);
+
+                assert.strictEqual(actualValue, expectedValue);
               }
             });
           });

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -128,11 +128,11 @@ describe('csproj', () => {
             it('should parse optional props as expected', () => {
               const targetReference = projectData.references.find(ref => ref.assemblyName === 'System');
 
-              assert.isUndefined(targetReference.version);
-              assert.isUndefined(targetReference.culture);
-              assert.isUndefined(targetReference.processorArchitecture);
-              assert.isUndefined(targetReference.publicKeyToken);
-              assert.isUndefined(targetReference.hintPath);
+              assert.isNull(targetReference.version);
+              assert.isNull(targetReference.culture);
+              assert.isNull(targetReference.processorArchitecture);
+              assert.isNull(targetReference.publicKeyToken);
+              assert.isNull(targetReference.hintPath);
             });
 
             describe('comparing parsed data to json', () => {
@@ -153,7 +153,7 @@ describe('csproj', () => {
                 for(let i=0; i < projectData.references.length; i++) {
                   for(let j=0; j < propNames.length; j++) {
                     const propName = propNames[j];
-                    assert.equal(projectData.references[i][propName], expectedData.references[i][propName]);
+                    assert.strictEqual(projectData.references[i][propName], expectedData.references[i][propName]);
                   }
                 }
               });
@@ -167,7 +167,7 @@ describe('csproj', () => {
 
             it('should parse code files correctly', () => {
               for(let i=0; i < projectData.codeFiles.length; i++) {
-                assert.equal(projectData.codeFiles[i].fileName, expectedData.codeFiles[i].fileName);
+                assert.strictEqual(projectData.codeFiles[i].fileName, expectedData.codeFiles[i].fileName);
               }
             });
           });
@@ -248,7 +248,7 @@ describe('csproj', () => {
                 for(let i=0; i < packageData.length; i++) {
                   for(let j=0; j < propNames.length; j++) {
                     const propName = propNames[j];
-                    assert.equal(packageData[i][propName], expectedData.packages[i][propName]);
+                    assert.strictEqual(packageData[i][propName], expectedData.packages[i][propName]);
                   }
                 }
               });

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const fs = require('fs-extra');
 const path = require('path');
 const csproj = require('../src/csproj');
+const helpers = require('../src/internal');
 
 describe('csproj', () => {
   describe('#parseProjectSync()', () => {
@@ -153,7 +154,13 @@ describe('csproj', () => {
                 for(let i=0; i < projectData.references.length; i++) {
                   for(let j=0; j < propNames.length; j++) {
                     const propName = propNames[j];
-                    assert.strictEqual(projectData.references[i][propName], expectedData.references[i][propName]);
+                    const actualValue = projectData.references[i][propName];
+                    let expectedValue = expectedData.references[i][propName];
+
+                    if (propName === 'hintPath')
+                      expectedValue = helpers.normalizePath(expectedValue);
+
+                    assert.strictEqual(actualValue, expectedValue);
                   }
                 }
               });

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -157,7 +157,7 @@ describe('csproj', () => {
                     const actualValue = projectData.references[i][propName];
                     let expectedValue = expectedData.references[i][propName];
 
-                    if (propName === 'hintPath')
+                    if (expectedValue && propName === 'hintPath')
                       expectedValue = helpers.normalizePath(expectedValue);
 
                     assert.strictEqual(actualValue, expectedValue);

--- a/test/expected/TestNUnit3.json
+++ b/test/expected/TestNUnit3.json
@@ -6,7 +6,7 @@
       "culture":"neutral",
       "processorArchitecture":"MSIL",
       "publicKeyToken":"b03f5f7f11d50a3a",
-      "hintPath":"../packages/MSTest.TestFramework.1.1.11/lib/net45/Microsoft.VisualStudio.TestPlatform.TestFramework.dll"
+      "hintPath":"..\\packages\\MSTest.TestFramework.1.1.11\\lib\\net45\\Microsoft.VisualStudio.TestPlatform.TestFramework.dll"
     },
     {
       "assemblyName":"Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions",
@@ -14,7 +14,7 @@
       "culture":"neutral",
       "processorArchitecture":"MSIL",
       "publicKeyToken":"b03f5f7f11d50a3a",
-      "hintPath":"../packages/MSTest.TestFramework.1.1.11/lib/net45/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll"
+      "hintPath":"..\\packages\\MSTest.TestFramework.1.1.11\\lib\\net45\\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll"
     },
     {
       "assemblyName":"nunit.framework",
@@ -22,7 +22,7 @@
       "culture":"neutral",
       "processorArchitecture":"MSIL",
       "publicKeyToken":"2638cd05610744eb",
-      "hintPath":"../packages/NUnit.3.7.1/lib/net45/nunit.framework.dll"
+      "hintPath":"..\\packages\\NUnit.3.7.1\\lib\\net45\\nunit.framework.dll"
     },
     {
       "assemblyName":"System",
@@ -43,16 +43,16 @@
   ],
   "codeFiles":[
     {
-      "fileName":"MyModule/ModuleClass.cs"
+      "fileName":"MyModule\\ModuleClass.cs"
     },
     {
-      "fileName":"MyModule/MySubmodule/Submodule.cs"
+      "fileName":"MyModule\\MySubmodule\\Submodule.cs"
     },
     {
       "fileName":"UnitTest1.cs"
     },
     {
-      "fileName":"Properties/AssemblyInfo.cs"
+      "fileName":"Properties\\AssemblyInfo.cs"
     }
   ],
   "packages":[


### PR DESCRIPTION
#### Description
Switching parsing of optional props to be null instead of undefined. This should make round-trip serialization more robust.

#### Related Issue
Fixes https://github.com/stevenaw/vs-parse/issues/17