### PR TITLE
Only parse Compile node if it has an Include attribute

### DIFF
--- a/src/csproj.js
+++ b/src/csproj.js
@@ -156,7 +156,7 @@ const parseProjectInternal = (contents) => {
         if (children[0].name === 'Reference') {
           const refs = children.map(parseAssemblyReference);
           projectData.references = projectData.references.concat(refs);
-        } else if (children[0].name === 'Compile') {
+        } else if (children[0].name === 'Compile' && children[0].attributes.Include) {
           const refs = children.map(parseCodeFile);
           projectData.codeFiles = projectData.codeFiles.concat(refs);
         } else if (children[0].name === 'PackageReference') {


### PR DESCRIPTION


#### Description
Check that the Compile node has an Include attribute before parsing

#### Related Issue
Fixes [[GH ISSUE]](https://github.com/stevenaw/vs-parse/issues/20)